### PR TITLE
Switch --platform flag to BuildProjects.lua

### DIFF
--- a/example/BuildProjects.bat
+++ b/example/BuildProjects.bat
@@ -1,4 +1,4 @@
-premake4 --os=windows --platform=x32 --file=BuildProjects.lua vs2010
-premake4 --os=macosx --platform=universal32 --file=BuildProjects.lua gmake
-premake4 --os=linux --platform=x32 --file=BuildProjects.lua gmake
+premake4 --os=windows --file=BuildProjects.lua vs2010
+premake4 --os=macosx --file=BuildProjects.lua gmake
+premake4 --os=linux --file=BuildProjects.lua gmake
 pause

--- a/example/BuildProjects.lua
+++ b/example/BuildProjects.lua
@@ -5,6 +5,12 @@ solution "gmsv_example"
 	flags { "Symbols", "NoEditAndContinue", "NoPCH", "StaticRuntime", "EnableSSE" }
 	targetdir ( "lib/" .. os.get() .. "/" )
 	includedirs { "../include/" }
+
+	if os.get() == "macosx" then
+		platform { "universal32" }
+	else
+		platform { "x32" }
+	end 
 	
 	configurations
 	{ 


### PR DESCRIPTION
The --platform flag to premake4 was still producing makefiles that compiled 64-bit binaries.
